### PR TITLE
Enhancement: Flexible Topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-[Full Changelog](https://github.com/NubeIO/nube_mqtt_dashboard_flutter/compare/v1.0.4...HEAD)
+[Full Changelog](https://github.com/NubeIO/nube_mqtt_dashboard_flutter/compare/v1.0.5...HEAD)
+
+
+## [1.0.5] - 2021-01-23
+[Full Changelog](https://github.com/NubeIO/nube_mqtt_dashboard_flutter/compare/v1.0.5...v1.0.5)
+
+### Added
+- Add Flexible Topics
 
 ## [1.0.4] - 2021-01-17
 [Full Changelog](https://github.com/NubeIO/nube_mqtt_dashboard_flutter/compare/v1.0.3...v1.0.4)
@@ -88,6 +95,7 @@ All notable changes to this project will be documented in this file.
 [Full Changelog](https://github.com/NubeIO/nube_mqtt_dashboard_flutter/compare/0f8e9bba816df883be8f32522e0679567f87f0ed...v0.0-alpha.1)
 
 [Unreleased]: https://github.com/NubeIO/nube_mqtt_dashboard_flutter/tree/HEAD
+[1.0.5]: https://github.com/NubeIO/nube_mqtt_dashboard_flutter/releases/tag/v1.0.5
 [1.0.4]: https://github.com/NubeIO/nube_mqtt_dashboard_flutter/releases/tag/v1.0.4
 [1.0.3]: https://github.com/NubeIO/nube_mqtt_dashboard_flutter/releases/tag/v1.0.3
 [1.0.2]: https://github.com/NubeIO/nube_mqtt_dashboard_flutter/releases/tag/v1.0.2

--- a/lib/application/layout/widget/widget_cubit.dart
+++ b/lib/application/layout/widget/widget_cubit.dart
@@ -52,7 +52,7 @@ class WidgetCubit extends Cubit<WidgetState> {
   }
 
   Future<void> init() async {
-    final topic = _widgetEntity.topic;
+    final topic = _widgetEntity.topic.read;
     await _widgetDataRepository.subscribeWidget(topic);
 
     stateSubscription =
@@ -93,7 +93,7 @@ class WidgetCubit extends Cubit<WidgetState> {
   }
 
   Future<bool> _setDataInternal(WidgetData value) async {
-    final topic = _widgetEntity.topic;
+    final topic = _widgetEntity.topic.write;
 
     final result = await _widgetDataRepository.setData(topic, value);
 

--- a/lib/data/layout/mappers/layout.dart
+++ b/lib/data/layout/mappers/layout.dart
@@ -67,7 +67,7 @@ class LayoutMapper {
   WidgetEntity mapToWidget(Widget widget) => widget.map(
         GAUGE: (widget) => WidgetEntity.gaugeWidget(
           id: widget.id,
-          topic: widget.topic,
+          topic: mapToFlexibleTopic(widget.topic),
           name: widget.name,
           config: mapToGaugeConfig(
             widget.config ?? GaugeConfigDto.fromJson({}),
@@ -75,7 +75,7 @@ class LayoutMapper {
         ),
         SWITCH: (widget) => WidgetEntity.switchWidget(
           id: widget.id,
-          topic: widget.topic,
+          topic: mapToFlexibleTopic(widget.topic),
           name: widget.name,
           config: mapToSwitchConfig(
             widget.config ?? SwitchConfigDto.fromJson({}),
@@ -83,7 +83,7 @@ class LayoutMapper {
         ),
         SLIDER: (widget) => WidgetEntity.sliderWidget(
           id: widget.id,
-          topic: widget.topic,
+          topic: mapToFlexibleTopic(widget.topic),
           name: widget.name,
           config: mapToSliderConfig(
             widget.config ?? SliderConfigDto.fromJson({}),
@@ -91,7 +91,7 @@ class LayoutMapper {
         ),
         VALUE: (widget) => WidgetEntity.valueWidget(
           id: widget.id,
-          topic: widget.topic,
+          topic: mapToFlexibleTopic(widget.topic),
           name: widget.name,
           config: mapToValueConfig(
             widget.config ?? ValueConfigDto.fromJson({}),
@@ -100,7 +100,7 @@ class LayoutMapper {
         SWITCH_GROUP: (widget) {
           return WidgetEntity.switchGroupWidget(
             id: widget.id,
-            topic: widget.topic,
+            topic: mapToFlexibleTopic(widget.topic),
             name: widget.name,
             config: mapToSwitchGroupConfig(
               widget.config ?? SwitchGroupConfigDto.fromJson({}),
@@ -110,7 +110,7 @@ class LayoutMapper {
         MAP: (widget) {
           return WidgetEntity.mapWidget(
             id: widget.id,
-            topic: widget.topic,
+            topic: mapToFlexibleTopic(widget.topic),
             name: widget.name,
             config: mapToMapConfig(
               widget.config ?? MapConfigDto.fromJson({}),
@@ -119,17 +119,24 @@ class LayoutMapper {
         },
         invalidParse: (value) => WidgetEntity.failure(
           id: widget.id,
-          topic: widget.topic,
+          topic: mapToFlexibleTopic(widget.topic),
           name: widget.name,
           failure: const LayoutParseFailure.parse(),
         ),
         unknownWidget: (value) => WidgetEntity.failure(
           id: widget.id,
-          topic: widget.topic,
+          topic: mapToFlexibleTopic(widget.topic),
           name: widget.name,
           failure: const LayoutParseFailure.unknown(),
         ),
       );
+
+  FlexibleTopic mapToFlexibleTopic(FlexibleTopicDto topic) {
+    return FlexibleTopic(
+      read: topic.read,
+      write: topic.write,
+    );
+  }
 
   GaugeConfig mapToGaugeConfig(GaugeConfigDto config) {
     return GaugeConfig(

--- a/lib/data/layout/repositories/layout_repository_impl.dart
+++ b/lib/data/layout/repositories/layout_repository_impl.dart
@@ -101,6 +101,7 @@ class LayoutRepositoryImpl extends ILayoutRepository {
   Future<Either<LayoutFailure, LayoutEntity>> _onErrorCatch(
     Object error,
   ) async {
+    Log.e("Layout Failure", ex: error);
     if (error is FormatException) {
       return left(const LayoutFailure.invalidLayout());
     } else {

--- a/lib/domain/layout/entities/widget.dart
+++ b/lib/domain/layout/entities/widget.dart
@@ -9,50 +9,61 @@ abstract class WidgetEntity with _$WidgetEntity {
   @Implements(NonEditableWidget)
   const factory WidgetEntity.gaugeWidget({
     @required String id,
-    @required String topic,
+    @required FlexibleTopic topic,
     @required String name,
     @required GaugeConfig config,
   }) = _GaugeWidget;
   @Implements(EditableWidget)
   const factory WidgetEntity.sliderWidget({
     @required String id,
-    @required String topic,
+    @required FlexibleTopic topic,
     @required String name,
     @required SliderConfig config,
   }) = _SliderWidget;
   @Implements(EditableWidget)
   const factory WidgetEntity.switchWidget({
     @required String id,
-    @required String topic,
+    @required FlexibleTopic topic,
     @required String name,
     @required SwitchConfig config,
   }) = _SwitchWidget;
   @Implements(NonEditableWidget)
   const factory WidgetEntity.valueWidget({
     @required String id,
-    @required String topic,
+    @required FlexibleTopic topic,
     @required String name,
     @required ValueConfig config,
   }) = _ValueWidget;
   @Implements(EditableWidget)
   const factory WidgetEntity.switchGroupWidget({
     @required String id,
-    @required String topic,
+    @required FlexibleTopic topic,
     @required String name,
     @required SwitchGroupConfig config,
   }) = _SwitchGroupWidget;
   const factory WidgetEntity.mapWidget({
     @required String id,
-    @required String topic,
+    @required FlexibleTopic topic,
     @required String name,
     @required MapConfig config,
   }) = _MapWidget;
   const factory WidgetEntity.failure({
     @required String id,
-    @required String topic,
+    @required FlexibleTopic topic,
     @required String name,
     @required LayoutParseFailure failure,
   }) = _FailureWidget;
+}
+
+@freezed
+abstract class FlexibleTopic with _$FlexibleTopic {
+  const factory FlexibleTopic({
+    @required String read,
+    @required String write,
+  }) = _FlexibleTopic;
+
+  factory FlexibleTopic.plain(String topic) =>
+      FlexibleTopic(read: topic, write: topic);
 }
 
 extension SliderWidgetExt on _SliderWidget {

--- a/lib/domain/layout/exceptions/layout.dart
+++ b/lib/domain/layout/exceptions/layout.dart
@@ -1,0 +1,1 @@
+class InvalidTopicException implements Exception {}

--- a/lib/presentation/pages/dashboard/widgets/widget_item.dart
+++ b/lib/presentation/pages/dashboard/widgets/widget_item.dart
@@ -166,7 +166,7 @@ class WidgetItem extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8),
       child: Text(
-        widgetEntity.topic,
+        widgetEntity.topic.read,
         style: Theme.of(context).textTheme.caption.copyWith(
               color: textColor,
             ),

--- a/lib/presentation/pages/preview/widgets/demo_layout.dart
+++ b/lib/presentation/pages/preview/widgets/demo_layout.dart
@@ -16,36 +16,36 @@ class DemoWidget extends StatelessWidget {
   }) : super(key: key);
 
   static const list = ["Item 1", "Item 2"];
-  static const widgets = [
+  static final widgets = [
     WidgetEntity.gaugeWidget(
       id: "1",
-      topic: "testTopic",
+      topic: FlexibleTopic.plain("testTopic"),
       name: "Gauge Widget",
-      config: GaugeConfig(max: 100, min: 0),
+      config: const GaugeConfig(max: 100, min: 0),
     ),
     WidgetEntity.valueWidget(
       id: "4",
-      topic: "testTopic",
+      topic: FlexibleTopic.plain("testTopic"),
       name: "Value Widget",
-      config: ValueConfig(unit: "C"),
+      config: const ValueConfig(unit: "C"),
     ),
     WidgetEntity.failure(
       id: "4",
-      topic: "testTopic",
+      topic: FlexibleTopic.plain("testTopic"),
       name: "Value Widget",
-      failure: LayoutParseFailure.unknown(),
+      failure: const LayoutParseFailure.unknown(),
     ),
     WidgetEntity.sliderWidget(
       id: "2",
-      topic: "testTopic",
+      topic: FlexibleTopic.plain("testTopic"),
       name: "Slider Widget",
-      config: SliderConfig(max: 100, min: 0, defaultValue: 0, step: 0.5),
+      config: const SliderConfig(max: 100, min: 0, defaultValue: 0, step: 0.5),
     ),
     WidgetEntity.switchWidget(
       id: "3",
-      topic: "testTopic",
+      topic: FlexibleTopic.plain("testTopic"),
       name: "Switch Widget",
-      config: SwitchConfig(defaultValue: false),
+      config: const SwitchConfig(defaultValue: false),
     ),
   ];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -363,7 +363,7 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3"
+    version: "0.12.7"
   freezed_annotation:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.4+4
+version: 1.0.5+5
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dev_dependencies:
   build_runner: 1.10.2
   device_preview: 0.4.8
   framy_generator: ^0.3.3
-  freezed: 0.12.3
+  freezed: 0.12.7
   injectable_generator: ^1.0.6
   json_serializable: ^3.5.1
   lint: ^1.3.0


### PR DESCRIPTION
## Task Completed
Add Flexible Topics
Bump to 1.0.5
Update CHANGELOG.md

## Details

Both of the scenarios below are valid config for a widget

Separate topics to read and write the values
````json
 "topic": {
    "read": "male1/read",
    "write": "male1/write"
}
````

Single topic to both read and write into. 
````json
"topic": "male1",
````