### PR TITLE
Add Support for Flexible Widget Size

### DIFF
--- a/lib/data/layout/models/layout.dart
+++ b/lib/data/layout/models/layout.dart
@@ -149,6 +149,7 @@ abstract class GlobalWidgetConfigDto with _$GlobalWidgetConfigDto {
     BackgroundConfigDto background,
     TitleConfigDto title,
     GlobalWidgetTypeConfigDto widget,
+    GridSizeDto grid,
     double initial,
   }) = _GlobalWidgetConfigDto;
 
@@ -333,6 +334,7 @@ abstract class WidgetConfigDto with _$WidgetConfigDto {
     double initial,
     BackgroundConfigDto background,
     TitleConfigDto title,
+    GridSizeDto grid,
   }) = GaugeConfigDto;
 
   const factory WidgetConfigDto.sliderConfig({
@@ -343,6 +345,7 @@ abstract class WidgetConfigDto with _$WidgetConfigDto {
     double initial,
     BackgroundConfigDto background,
     TitleConfigDto title,
+    GridSizeDto grid,
   }) = SliderConfigDto;
 
   const factory WidgetConfigDto.switchConfig({
@@ -350,6 +353,7 @@ abstract class WidgetConfigDto with _$WidgetConfigDto {
     double initial,
     BackgroundConfigDto background,
     TitleConfigDto title,
+    GridSizeDto grid,
   }) = SwitchConfigDto;
 
   const factory WidgetConfigDto.valueConfig({
@@ -359,6 +363,7 @@ abstract class WidgetConfigDto with _$WidgetConfigDto {
     @JsonKey(unknownEnumValue: AlignmentType.LEFT) AlignmentType align,
     BackgroundConfigDto background,
     TitleConfigDto title,
+    GridSizeDto grid,
   }) = ValueConfigDto;
 
   const factory WidgetConfigDto.switchGroupConfig({
@@ -367,6 +372,7 @@ abstract class WidgetConfigDto with _$WidgetConfigDto {
     double initial,
     BackgroundConfigDto background,
     TitleConfigDto title,
+    GridSizeDto grid,
   }) = SwitchGroupConfigDto;
 
   const factory WidgetConfigDto.mapConfig({
@@ -377,16 +383,29 @@ abstract class WidgetConfigDto with _$WidgetConfigDto {
     double initial,
     BackgroundConfigDto background,
     TitleConfigDto title,
+    GridSizeDto grid,
   }) = MapConfigDto;
 
   const factory WidgetConfigDto.emptyConfig({
     double initial,
     BackgroundConfigDto background,
     TitleConfigDto title,
+    GridSizeDto grid,
   }) = EmptyConfigDto;
 
   factory WidgetConfigDto.fromJson(Map<String, dynamic> json) =>
       _$WidgetConfigDtoFromJson(json);
+}
+
+@freezed
+abstract class GridSizeDto with _$GridSizeDto {
+  const factory GridSizeDto({
+    @JsonKey(name: 'row_span') int rowSpan,
+    @JsonKey(name: 'column_span') int columnSpan,
+  }) = _GridSizeDto;
+
+  factory GridSizeDto.fromJson(Map<String, dynamic> json) =>
+      _$GridSizeDtoFromJson(json);
 }
 
 @freezed

--- a/lib/domain/layout/entities/widget.dart
+++ b/lib/domain/layout/entities/widget.dart
@@ -67,6 +67,7 @@ abstract class GlobalConfig with _$GlobalConfig {
   const factory GlobalConfig({
     @required BackgroundConfig background,
     @required TitleConfig title,
+    GridSize gridSize,
     double initial,
   }) = _GlobalConfig;
 
@@ -117,6 +118,14 @@ abstract class TitleConfig with _$TitleConfig {
         align: const Alignment.left(),
         colors: emptyMap(),
       );
+}
+
+@freezed
+abstract class GridSize with _$GridSize {
+  const factory GridSize({
+    @required int rowSpan,
+    @required int columnSpan,
+  }) = _GridSize;
 }
 
 @freezed

--- a/lib/presentation/pages/dashboard/widgets/page_screen.dart
+++ b/lib/presentation/pages/dashboard/widgets/page_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:nube_mqtt_dashboard/utils/logger/log.dart';
 
 import '../../../../application/layout/pages/pages_cubit.dart';
 import '../../../../domain/layout/entities.dart';
@@ -42,20 +43,43 @@ class WidgetsScreen extends StatelessWidget {
       itemCount: page.widgets.size,
       staggeredTileBuilder: (index) {
         final widget = page.widgets[index];
+        final rowSpan = widget.globalConfig.gridSize?.rowSpan;
+        final columnSpan = widget.globalConfig.gridSize?.columnSpan;
+        Log.i("Widget ${widget.name} $rowSpan x $columnSpan");
         return widget.map(
-          gaugeWidget: (_) =>
-              StaggeredTile.count(widthCount * 2, heightCalc * 2),
+          gaugeWidget: (_) => StaggeredTile.count(
+            widthCount * (rowSpan ?? 2),
+            heightCalc * (columnSpan ?? 2),
+          ),
           sliderWidget: (_) {
-            return StaggeredTile.count(widthCount * 2, heightCalc);
+            return StaggeredTile.count(
+              widthCount * (rowSpan ?? 2),
+              heightCalc * (columnSpan ?? 1),
+            );
           },
-          switchWidget: (_) => StaggeredTile.count(widthCount, heightCalc),
-          valueWidget: (_) => StaggeredTile.count(widthCount, heightCalc),
+          switchWidget: (_) => StaggeredTile.count(
+            widthCount * (rowSpan ?? 1),
+            heightCalc * (columnSpan ?? 1),
+          ),
+          valueWidget: (_) => StaggeredTile.count(
+            widthCount * (rowSpan ?? 1),
+            heightCalc * (columnSpan ?? 1),
+          ),
           switchGroupWidget: (widget) {
             final cellSpan = widget.config.items.size > 1 ? 2 : 1;
-            return StaggeredTile.count(widthCount * cellSpan, heightCalc);
+            return StaggeredTile.count(
+              widthCount * (rowSpan ?? cellSpan),
+              heightCalc * (columnSpan ?? 1),
+            );
           },
-          mapWidget: (_) => StaggeredTile.count(widthCount, heightCalc),
-          failure: (_) => StaggeredTile.count(widthCount, heightCalc),
+          mapWidget: (_) => StaggeredTile.count(
+            widthCount * (rowSpan ?? 1),
+            heightCalc * (columnSpan ?? 1),
+          ),
+          failure: (_) => StaggeredTile.count(
+            widthCount * (rowSpan ?? 1),
+            heightCalc * (columnSpan ?? 1),
+          ),
         );
       },
     );


### PR DESCRIPTION
Added support for flexible widget size configs. This can added globally to all widgets through `widget_config` or to specifically to specific widget types, or individual widgets. 

```
"grid": {
  "row_span": 2,
  "column_span": 1
}
```